### PR TITLE
Move from jquery library to axios for HTTP requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --ext .js,.vue src test/unit/specs test/e2e/specs"
   },
   "dependencies": {
-    "jquery": "^3.2.1",
+    "axios": "^0.16.2",
     "vue": "^2.2.2",
     "vue-router": "^2.2.0"
   },

--- a/resources/assets/js/src/components/Hello.vue
+++ b/resources/assets/js/src/components/Hello.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script>
-import {get} from 'jquery'
+import axios from 'axios'
 
 export default {
   name: 'hello',
@@ -43,11 +43,14 @@ export default {
   },
   mounted () {
     console.log('mounted')
-
-    get('/api/test', {}, (res) => {
-      console.log(res)
-      this.testData = res
-    })
+    axios.get('/api/test')
+      .then((response) => {
+        // console.log(response)
+        this.testData = response.data
+      })
+      .catch((error) => {
+        console.log(error)
+      })
   }
 }
 </script>


### PR DESCRIPTION
Move from jQuery to Axios for HTTP requests. Axios is a promise based, single purpose library for HTTP requests so I'd think it would be a better fit than using `get` from jQuery.

I'm really enjoying working with your boilerplate project here! Thanks for it.